### PR TITLE
Add runner/main for figwheel's repl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ out/
 huckleberry.iml
 target/
 .lein-repl-history
+figwheel_server.log

--- a/project.clj
+++ b/project.clj
@@ -6,18 +6,20 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.229"]
+                 [org.clojure/clojurescript "1.9.293"]
                  [andare "0.4.0"]]
 
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-cljfmt "0.5.3"]
-            [lein-doo "0.1.7"]
+
             [lein-npm "0.6.2"]]
 
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure" "src/main/clojure"]
 
   :clean-targets ["main.js" "out" "target"]
+
+  :main "out/main.js" ;; downloads npm deps and run
 
   :npm {
         :dependencies [[xml2js "0.4.17"]
@@ -28,10 +30,10 @@
   :cljsbuild {
               :builds [
                        {:id "dev"
-                        :source-paths ["src/main/clojure"]
+                        :source-paths ["src/main/clojure" "src/dev/clojure"]
                         :figwheel true
                         :compiler {
-                                   :main eginez.huckleberry.core
+                                   :main eginez.huckleberry.runner
                                    :output-to "out/main.js"
                                    :target :nodejs
                                    :output-dir "out"
@@ -49,4 +51,10 @@
                                    :parallel-build true
                                    :source-map true}
                         }
-                       ]}) 
+                       ]}
+  :figwheel {}
+  :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.2.1"]
+                                  [org.clojure/tools.nrepl "0.2.12"]]
+                   :plugins [[lein-doo "0.1.7"]
+                             [lein-figwheel "0.5.8" :exclusions [cider/cider-nrepl]]]
+                   :npm {:dependencies [[ws "1.1.1"]]}}})

--- a/src/dev/clojure/eginez/huckleberry/runner.cljs
+++ b/src/dev/clojure/eginez/huckleberry/runner.cljs
@@ -1,0 +1,9 @@
+(ns ^:figwheel-always eginez.huckleberry.runner
+  (:require [cljs.nodejs :as nodejs]))
+
+(nodejs/enable-util-print!)
+
+(defn -main []
+  (println "Huckleberry runner started!"))
+
+(set! cljs.core/*main-cli-fn* -main)


### PR DESCRIPTION
In the first terminal run `lein figwheel repl`, in the second terminal run `lein run`.