### PR TITLE
Interpolate dependencies & lookup parent dep where necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Will return channel that will output the status of each of the files that need t
 
 For more examples on how to use the library look in the test [directory](https://github.com/eginez/huckleberry/blob/master/src/test/clojure/eginez/huckleberry/core_test.cljs)
 
+## Running the tests
+
+Run `lein deps` followed by `lein doo node test`.
+
 ## License
 
 Copyright (C) 2016 Esteban Ginez

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Huckleberry aims to be a jvm-less replacement for [Pomergranate](https://github.
 * Maven dependencies expressed in lein style coordinates eg: [commons-logging "1.0"]
 * Local repo
 * Exclusions
+* Resolving transient dependencies via the parent or using versions interpolated from the properties in the POM file where required.
 
 ## Huckleberry does not support
 * Proxies or Mirrors

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.eginez/huckleberry "0.2.0"
+(defproject org.clojars.eginez/huckleberry "0.2.1"
   :url "https://github.com/eginez/huckleberry"
   :description "maven dependecy resolution in clojurescript"
   :min-lein-version "2.5.3"

--- a/src/test/clojure/eginez/huckleberry/core_test.cljs
+++ b/src/test/clojure/eginez/huckleberry/core_test.cljs
@@ -16,6 +16,7 @@
 (def test-dep6 {:group "commons-logging" :artifact "commons-logging" :version "1.1"
                 :exclusions [{:group "avalon-framework" :artifact "avalon-framework" :version "4.1.3"}]})
 (def test-dep7 {:group "org.clojure" :artifact "core.specs.alpha" :version "0.1.24"})
+(def test-dep8 {:group "org.apache.httpcomponents" :artifact "httpasyncclient" :version "4.1.3"})
 
 (def test-url (huckleberry/create-urls-for-dependency (:maven-central huckleberry/default-repos) test-dep))
 
@@ -36,6 +37,17 @@
   (async done
     (go
       (let [[status d locations] (<! (huckleberry/resolve test-dep7 :repositories (vals huckleberry/default-repos)))]
+        (assert (true? status))
+        (assert (= 4 (-> d keys count)))
+        (assert (= 4 (-> locations count)))
+        (done)))))
+
+(deftest test-resolve-single-with-parent
+  (async done
+    (go
+      (let [[status d locations] (<! (huckleberry/resolve test-dep8 :repositories (vals huckleberry/default-repos)))]
+        (println (-> d keys count))
+        (println (-> locations count))
         (assert (true? status))
         (assert (= 4 (-> d keys count)))
         (assert (= 4 (-> locations count)))

--- a/src/test/clojure/eginez/huckleberry/core_test.cljs
+++ b/src/test/clojure/eginez/huckleberry/core_test.cljs
@@ -38,8 +38,8 @@
     (go
       (let [[status d locations] (<! (huckleberry/resolve test-dep7 :repositories (vals huckleberry/default-repos)))]
         (assert (true? status))
-        (assert (= 4 (-> d keys count)))
-        (assert (= 4 (-> locations count)))
+        (assert (= 7 (-> d keys count)))
+        (assert (= 7 (-> locations count)))
         (done)))))
 
 (deftest test-resolve-single-with-parent

--- a/src/test/clojure/eginez/huckleberry/core_test.cljs
+++ b/src/test/clojure/eginez/huckleberry/core_test.cljs
@@ -15,6 +15,7 @@
 (def test-dep5 {:group "org.clojure" :artifact "clojure" :version "1.8.0"})
 (def test-dep6 {:group "commons-logging" :artifact "commons-logging" :version "1.1"
                 :exclusions [{:group "avalon-framework" :artifact "avalon-framework" :version "4.1.3"}]})
+(def test-dep7 {:group "org.clojure" :artifact "core.specs.alpha" :version "0.1.24"})
 
 (def test-url (huckleberry/create-urls-for-dependency (:maven-central huckleberry/default-repos) test-dep))
 
@@ -29,6 +30,15 @@
         (assert (true? status))
         (assert (= 5 (-> d keys count)))
         (assert (= 5 (-> locations count)))
+        (done)))))
+
+(deftest test-resolve-single-with-variable-interpolation
+  (async done
+    (go
+      (let [[status d locations] (<! (huckleberry/resolve test-dep7 :repositories (vals huckleberry/default-repos)))]
+        (assert (true? status))
+        (assert (= 4 (-> d keys count)))
+        (assert (= 4 (-> locations count)))
         (done)))))
 
 (deftest test-resolve-all-single


### PR DESCRIPTION
I noticed that this library was failing to download dependencies who's pom files contained dependencies which needed to have values interpolated from the properties section of the pom file, e.g.:

https://repo1.maven.org/maven2/org/clojure/core.specs.alpha/0.1.24/core.specs.alpha-0.1.24.pom

has the following in its dependencies:

```
<dependency>
<groupId>org.clojure</groupId>
<artifactId>clojure</artifactId>
<version>${clojure.version}</version>
<scope>provided</scope>
</dependency>
```

The `${clojure.version}` needs to be interpolated from the properties section above it:
```
<properties>
<clojure.version>1.9.0-alpha15</clojure.version>
</properties>
```

This PR adds a test case for this and updates the code to interpolate any values needed within the dependencies section of the pom file.

I also noticed that it would fail on a pom file who's dependencies did not contain versions because they were intended to be retrieved by the parent library. This PR also includes a fix for that, which is to discard any dependencies with nil values for version, and add the parent dependency in their place.

An example of a dependency like this is `org.apache.httpcomponents/httpasyncclient 4.1.3`.